### PR TITLE
remove last two panics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,14 +127,8 @@ fn generate_hash(hash: &Hashes, data: &str) -> String {
 // Read lines from file into a Vec<String>
 fn read_file(filename: &str) -> Result<Vec<String>, Box<Error>> {
     let mut buffer = String::new();
-    let mut f = match File::open(filename) {
-        Ok(f) => f,
-        Err(why) => panic!("Unable to open file {}: {}", filename, why.description())
-    };
-    match f.read_to_string(&mut buffer) {
-        Ok(x) => x,
-        Err(why) => panic!("Unable to read from file: {}", why.description())
-    };
+    let mut f = File::open(filename)?;
+    f.read_to_string(&mut buffer)?;
 
     let x = buffer
             .lines()


### PR DESCRIPTION
we can use the question mark operator here since the function returns
a Result. 

With the question mark operator the function will do a early return if a 
error occurs. And the `ok_or_exit!(read_file(&config.filename[..]), "failed to read file")`
will catch the error prints it to 'stderr' and exit the program

example output if file not exist:

    $ target/debug/hashmash -f non-existing-file -m x
    ERROR: failed to read file: No such file or directory (os error 2)
